### PR TITLE
Update groundings fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,17 @@ Adeft's pretrained machine learning models can then be downloaded with the comma
 
     $ python -m adeft.download
 
+If you choose to install by cloning this repository
+
+    $ git clone https://github.com/indralab/adeft.git
+
+You should also run
+
+    $ python setup.py build_ext --inplace
+
+at the top level of your local repository in order to build Cython extensions for
+alignment based longform recognition. 
+
 ## Using Adeft
 A dictionary of available models can be imported with `from adeft import available_models`
 

--- a/adeft/disambiguate.py
+++ b/adeft/disambiguate.py
@@ -178,11 +178,11 @@ class AdeftDisambiguator(object):
             self.names = names
             # Update groundings in grounding_dict
             self.grounding_dict = {shortform:
-                                   {(new_groundings[grounding]
+                                   {phrase:
+                                    (new_groundings[grounding]
                                     if grounding in new_groundings
-                                    else grounding):
-                                    name
-                                    for grounding, name in
+                                     else grounding)
+                                    for phrase, grounding in
                                     grounding_map.items()}
                                    for shortform, grounding_map
                                    in self.grounding_dict.items()}

--- a/adeft/gui/__init__.py
+++ b/adeft/gui/__init__.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 def ground_with_gui(longforms, scores, grounding_map=None,
                     names=None, pos_labels=None, verbose=False, port=5000,
-                    test=False):
+                    no_browser=False, test=False):
     """Opens grounding GUI in browser. Returns output upon user submission.
 
     Parameters
@@ -40,6 +40,9 @@ def ground_with_gui(longforms, scores, grounding_map=None,
     port : Optional[int]
         Port where flask is served. Defaults to flask's default.
         Default: 5000
+    no_browser : Optional[bool]
+        When True, do not automatically open GUI in browser
+        Default: False
     test : Optional[bool]
         If True the Flask app is replaced with a mock version for testing.
         Default: False
@@ -99,7 +102,7 @@ def ground_with_gui(longforms, scores, grounding_map=None,
     flask_server = Process(target=lambda: app.run(port=port))
     flask_server.start()
     # Open app in browser unless a test is being run
-    if not test:
+    if not test and not no_browser:
         webbrowser.open('http://localhost:%d/' % port)
     # Poll until user submits groundings. Checks if output file exists
     while not os.path.exists(os.path.join(outpath, 'output.json')):

--- a/adeft/recognize.py
+++ b/adeft/recognize.py
@@ -11,12 +11,12 @@ from adeft.nlp import tokenize, untokenize
 from adeft.util import get_candidate_fragments, get_candidate
 
 logger = logging.getLogger(__file__)
-    
+
 try:
     from adeft.score import AdeftLongformScorer
 except Exception:
-    logger.warning('OneShotRecognizer not available. AdeftLongformScorer'
-                   ' has not been built successfully.')
+    logger.info('OneShotRecognizer not available. AdeftLongformScorer'
+                ' has not been built successfully.')
 
 _stemmer = EnglishStemmer()
 

--- a/adeft/recognize.py
+++ b/adeft/recognize.py
@@ -8,11 +8,15 @@ import logging
 from nltk.stem.snowball import EnglishStemmer
 
 from adeft.nlp import tokenize, untokenize
-from adeft.score import AdeftLongformScorer
 from adeft.util import get_candidate_fragments, get_candidate
 
-
 logger = logging.getLogger(__file__)
+    
+try:
+    from adeft.score import AdeftLongformScorer
+except Exception:
+    logger.warning('OneShotRecognizer not available. AdeftLongformScorer'
+                   ' has not been built successfully.')
 
 _stemmer = EnglishStemmer()
 
@@ -270,7 +274,12 @@ class OneShotRecognizer(BaseRecognizer):
         Parameters for :py:class`adeft.score.AdeftLongformScorer`
     """
     def __init__(self, shortform, window=100, exclude=None, **params):
-        self.scorer = AdeftLongformScorer(shortform, **params)
+        try:
+            self.scorer = AdeftLongformScorer(shortform, **params)
+        except NameError:
+            logger.exception('OneShotRecognizer not available.'
+                             ' AdeftLongformScorer has not been built'
+                             ' successfully.')
         super().__init__(shortform, window, exclude)
 
     def _search(self, tokens):

--- a/adeft/tests/test_disambiguate.py
+++ b/adeft/tests/test_disambiguate.py
@@ -99,6 +99,7 @@ def test_modify_groundings():
     assert 'UP:P06213' in ad.classifier.pos_labels
     assert 'UP:P06213' in ad.classifier.estimator.classes_
     assert 'UP:P06213' in ad.names
+    assert 'UP:P06213' in ad.grounding_dict['IR'].values()
     assert ad.names['UP:P06213'] == 'Insulin Receptor'
 
 


### PR DESCRIPTION
This PR fixes a bug in the method AdeftDisambiguator.modify_groundings that allows the groundings of an existing disambiguator to be changed without retraining the underlying machine learning models. In addition, the GUI for manually annotating longforms with groundings has been updated to provide an option to not automatically open the browser. This will be helpful if we are working on a remote server. I'm building a workflow for constructing models that uses port forwarding. Guards have also been placed around the AdeftLongformScorer so that all functionality that does not depend on it will still work even if the necessary Cython extensions have not been built.