### PR TITLE
Model path bug

### DIFF
--- a/adeft/disambiguate.py
+++ b/adeft/disambiguate.py
@@ -332,13 +332,17 @@ def load_disambiguator(shortform, path=ADEFT_MODELS_PATH):
         logger.error('No model available for shortform %s' % shortform)
         return None
 
-    model = load_model(os.path.join(path, model_name,
-                                    model_name + '_model.gz'))
-    with open(os.path.join(path, model_name,
-                           model_name + '_grounding_dict.json')) as f:
+    output = load_disambiguator_directly(os.path.join(path, model_name))
+    return output
+
+
+def load_disambiguator_directly(path):
+    model_name = os.path.basename(os.path.abspath(path))
+    model = load_model(os.path.join(path, model_name + '_model.gz'))
+    with open(os.path.join(path, model_name + '_grounding_dict.json')) as f:
         grounding_dict = json.load(f)
-    with open(os.path.join(path, model_name,
-                           model_name + '_names.json')) as f:
+    with open(os.path.join(path, model_name + '_names.json')) as f:
         names = json.load(f)
     output = AdeftDisambiguator(model, grounding_dict, names)
     return output
+    

--- a/adeft/disambiguate.py
+++ b/adeft/disambiguate.py
@@ -337,6 +337,20 @@ def load_disambiguator(shortform, path=ADEFT_MODELS_PATH):
 
 
 def load_disambiguator_directly(path):
+    """Returns disambiguator located at path
+    
+    Parameters
+    ----------
+    path : str
+        Path to a disambiguation model. Must be a path to a directory
+       <model_name> containing the files
+       <model_name>_model.gz, <model_name>_grounding_dict.json, <model_name>_names.json
+       
+    Returns
+    -------
+    py:class:`adeft.disambiguate.AdeftDisambiguator`
+        A disambiguation model loaded from folder specified by path
+    """
     model_name = os.path.basename(os.path.abspath(path))
     model = load_model(os.path.join(path, model_name + '_model.gz'))
     with open(os.path.join(path, model_name + '_grounding_dict.json')) as f:

--- a/adeft/disambiguate.py
+++ b/adeft/disambiguate.py
@@ -303,7 +303,11 @@ class AdeftDisambiguator(object):
 
 
 def load_disambiguator(shortform, path=ADEFT_MODELS_PATH):
-    """Returns deft disambiguator loaded from models directory
+    """Returns adeft disambiguator loaded from models directory
+
+    Searches folder specified by path for a disambiguation model
+    that can disambiguate the given shortform and returns this
+    model
 
     Parameters
     ----------
@@ -317,7 +321,9 @@ def load_disambiguator(shortform, path=ADEFT_MODELS_PATH):
     Returns
     -------
     py:class:`adeft.disambiguate.AdeftDisambiguator`
-        A disambiguator that was loaded from a file.
+        A disambiguator that was loaded from a file. Returns None if there
+        are no disambiguation models in the supplied folder that can
+        disambiguate the given shortform
     """
     available = get_available_models(path=path)
     try:

--- a/adeft/download/download.py
+++ b/adeft/download/download.py
@@ -114,16 +114,19 @@ def get_available_models(path=ADEFT_MODELS_PATH):
     for model in os.listdir(path):
         model_path = os.path.join(path, model)
         if os.path.isdir(model_path) and model != '__pycache__':
-            grounding_file = '%s_grounding_dict.json' % model
-            with open(os.path.join(model_path, grounding_file), 'r') as f:
-                grounding_dict = json.load(f)
-            for key, value in grounding_dict.items():
-                if key in output:
-                    logger.warning('Shortform %s has multiple adeft models'
-                                   'This may lead to unexpected behavior'
-                                   % key)
-                else:
-                    output[key] = model
+            try:
+                grounding_file = '%s_grounding_dict.json' % model
+                with open(os.path.join(model_path, grounding_file), 'r') as f:
+                    grounding_dict = json.load(f)
+                for key, value in grounding_dict.items():
+                    if key in output:
+                        logger.warning('Shortform %s has multiple adeft models'
+                                       'This may lead to unexpected behavior'
+                                       % key)
+                    else:
+                        output[key] = model
+            except FileNotFoundError:
+                continue
     return output
 
 

--- a/adeft/modeling/classify.py
+++ b/adeft/modeling/classify.py
@@ -294,7 +294,7 @@ def load_model_info(model_info):
     tfidf.vocabulary_ = model_info['tfidf']['vocabulary_']
     tfidf.idf_ = model_info['tfidf']['idf_']
     logit.classes_ = np.array(model_info['logit']['classes_'],
-                              dtype='<U32')
+                              dtype='<U64')
     logit.intercept_ = np.array(model_info['logit']['intercept_'])
     logit.coef_ = np.array(model_info['logit']['coef_'])
 


### PR DESCRIPTION
This PR fixes a bug in `adeft.disambiguate.load_disambiguator` that caused an error if the supplied path contains files or folders other than adeft models. Now any such files and folders are skipped. Also, a new function has been added `adeft.disambiguate.load_disambiguator_directly` that loads a disambiguator directly from its filepath. The existing `load_disambiguator` instead searches for disambiguators in a given path that can disambiguate a supplied shortform. These changes are convenient for users interactively building their own models, but will not affect users who only use the pretrained models.

An unrelated fix was also made allowing disambiguation models to have predicted labels exceeding 32 characters in length. 