### PR TITLE
Feature importance

### DIFF
--- a/adeft/__init__.py
+++ b/adeft/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.5.3'
+__version__ = '0.5.4'
 
 from adeft.download import get_available_models
 

--- a/adeft/modeling/classify.py
+++ b/adeft/modeling/classify.py
@@ -276,6 +276,11 @@ class AdeftClassifier(object):
         logit = self.estimator.named_steps['logit']
         feature_names = tfidf.get_feature_names()
         classes = logit.classes_
+        # Binary and multiclass cases most be handled separately
+        # When there are greater than two classes, the logistic
+        # regression model will have a row of coefficients for
+        # each class. When there are only two classes, there is
+        # only one row of coefficients corresponding to the label classes[1]
         if len(classes) > 2:
             for index, label in enumerate(classes):
                 importance = logit.coef_[index] * self._std
@@ -283,11 +288,11 @@ class AdeftClassifier(object):
                                        key=lambda x: -x[1])
         else:
             importance = np.squeeze(logit.coef_) * self._std
-            output[classes[0]] = sorted(zip(feature_names, importance),
+            output[classes[1]] = sorted(zip(feature_names, importance),
                                         key=lambda x: -x[1])
-            output[classes[1]] = [(feature, -value)
+            output[classes[0]] = [(feature, -value)
                                   for feature, value
-                                  in output[classes[0]][::-1]]
+                                  in output[classes[1]][::-1]]
         return output
 
     def _set_variance(self, texts):

--- a/adeft/modeling/classify.py
+++ b/adeft/modeling/classify.py
@@ -1,3 +1,4 @@
+import os
 import gzip
 import json
 import logging
@@ -232,8 +233,12 @@ class AdeftClassifier(object):
                       'shortforms': self.shortforms,
                       'pos_labels': self.pos_labels}
         # Add model statistics if they are available
-        if hasattr(self, 'stats') and self.stats:
+        if hasattr(self, 'stats') and self.stats is not None:
             model_info['stats'] = self.stats
+        # Add standard deviations used for calculating feature importances
+        # if they are available
+        if hasattr(self, '_std') and self._std is not None:
+            model_info['std'] = self._std.tolist()
         return model_info
 
     def dump_model(self, filepath):
@@ -369,4 +374,8 @@ def load_model_info(model_info):
     # Load model statistics if they are available
     if 'stats' in model_info:
         longform_model.stats = model_info['stats']
+    # Load standard deviations for calculating feature importances
+    # if they are available
+    if 'std' in model_info:
+        longform_model._std = np.array(model_info['std'])
     return longform_model

--- a/adeft/modeling/classify.py
+++ b/adeft/modeling/classify.py
@@ -53,7 +53,7 @@ class AdeftClassifier(object):
         self.stats = None
         self.estimator = None
         self.best_score = None
-        self.cv_results = None
+        self.grid_search = None
         self._std = None
 
     def train(self, texts, y, C=1.0, ngram_range=(1, 2), max_features=1000):
@@ -91,7 +91,7 @@ class AdeftClassifier(object):
         logit_pipeline.fit(texts, y)
         self.estimator = logit_pipeline
         self.best_score = None
-        self.cv_results = None
+        self.grid_search = None
         self._set_variance(texts)
 
     def cv(self, texts, y, param_grid, n_jobs=1, cv=5):
@@ -189,7 +189,7 @@ class AdeftClassifier(object):
 
         self.estimator = grid_search.best_estimator_
         self.best_score = grid_search.best_score_
-        self.cv_results = grid_search.cv_results_
+        self.grid_search = grid_search
         self.stats = stats
         self._set_variance(texts)
 

--- a/adeft/modeling/classify.py
+++ b/adeft/modeling/classify.py
@@ -53,7 +53,7 @@ class AdeftClassifier(object):
         self.stats = None
         self.estimator = None
         self.best_score = None
-        self.grid_search = None
+        self.cv_results = None
 
     def train(self, texts, y, C=1.0, ngram_range=(1, 2), max_features=1000):
         """Fits a disambiguation model
@@ -90,7 +90,7 @@ class AdeftClassifier(object):
         logit_pipeline.fit(texts, y)
         self.estimator = logit_pipeline
         self.best_score = None
-        self.grid_search = None
+        self.cv_results = None
 
     def cv(self, texts, y, param_grid, n_jobs=1, cv=5):
         """Performs grid search to select and fit a disambiguation model
@@ -187,7 +187,7 @@ class AdeftClassifier(object):
 
         self.estimator = grid_search.best_estimator_
         self.best_score = grid_search.best_score_
-        self.grid_search = grid_search
+        self.cv_results = grid_search.cv_results_
         self.stats = stats
 
     def predict_proba(self, texts):

--- a/adeft/modeling/classify.py
+++ b/adeft/modeling/classify.py
@@ -275,10 +275,19 @@ class AdeftClassifier(object):
         tfidf = self.estimator.named_steps['tfidf']
         logit = self.estimator.named_steps['logit']
         feature_names = tfidf.get_feature_names()
-        for index, label in enumerate(logit.classes_):
-            importance = logit.coef_[index] * self._std
-            output[label] = sorted(zip(feature_names, importance),
-                                   key=lambda x: -x[1])
+        classes = logit.classes_
+        if len(classes) > 2:
+            for index, label in enumerate(classes):
+                importance = logit.coef_[index] * self._std
+                output[label] = sorted(zip(feature_names, importance),
+                                       key=lambda x: -x[1])
+        else:
+            importance = np.squeeze(logit.coef_) * self._std
+            output[classes[0]] = sorted(zip(feature_names, importance),
+                                        key=lambda x: -x[1])
+            output[classes[1]] = [(feature, -value)
+                                  for feature, value
+                                  in output[classes[0]][::-1]]
         return output
 
     def _set_variance(self, texts):

--- a/adeft/tests/test_classify.py
+++ b/adeft/tests/test_classify.py
@@ -78,7 +78,14 @@ def test_feature_importance_multiclass():
     assert isinstance(feature_importances, dict)
     assert set(feature_importances.keys()) == set(labels)
     for label, importances in feature_importances.items():
+        # check that importances are sorted
         assert importances == sorted(importances, key=lambda x: -x[1])
+        # check that output is of the correct type
+        assert all(isinstance(x, tuple) and
+                   len(x) == 2 and
+                   isinstance(x[0], str) and
+                   isinstance(x[1], float)
+                   for x in importances)
 
 
 @attr('slow')
@@ -95,7 +102,14 @@ def test_feature_importance_binary():
     assert isinstance(feature_importances, dict)
     assert set(feature_importances.keys()) == set(labels)
     for label, importances in feature_importances.items():
+        # check that importances are sorted
         assert importances == sorted(importances, key=lambda x: -x[1])
+        # check that output is of the correct type
+        assert all(isinstance(x, tuple) and
+                   len(x) == 2 and
+                   isinstance(x[0], str) and
+                   isinstance(x[1], float)
+                   for x in importances)
 
 
 def test_serialize():

--- a/adeft/tests/test_classify.py
+++ b/adeft/tests/test_classify.py
@@ -140,6 +140,13 @@ def test_serialize():
     preds1, preds2, preds3 = (classifier1.predict_proba(texts),
                               classifier2.predict_proba(texts),
                               classifier3.predict_proba(texts))
+    # Check that generated predictions are the same
     assert np.array_equal(preds1, preds2)
     assert np.array_equal(preds2, preds3)
+    # Check that model stats are the same
+    assert classifier1.stats == classifier2.stats == classifier3.stats
+    # Check that the calculated feature importance scores are the same
+    assert classifier1.feature_importances() == \
+        classifier2.feature_importances() == \
+        classifier3.feature_importances()
     os.remove(temp_filename)

--- a/adeft/tests/test_classify.py
+++ b/adeft/tests/test_classify.py
@@ -66,13 +66,30 @@ def test_cv_binary():
 
 
 @attr('slow')
-def test_feature_importance():
+def test_feature_importance_multiclass():
     params = {'C': 1.0,
               'ngram_range': (1, 2),
               'max_features': 1000}
     classifier = AdeftClassifier('IR', ['HGNC:6091', 'MESH:D011839'])
     texts = data['texts']
     labels = data['labels']
+    classifier.train(texts, labels, **params)
+    feature_importances = classifier.feature_importances()
+    assert isinstance(feature_importances, dict)
+    assert set(feature_importances.keys()) == set(labels)
+    for label, importances in feature_importances.items():
+        assert importances == sorted(importances, key=lambda x: -x[1])
+
+
+@attr('slow')
+def test_feature_importance_binary():
+    params = {'C': 1.0,
+              'ngram_range': (1, 2),
+              'max_features': 1000}
+    classifier = AdeftClassifier('IR', ['HGNC:6091', 'MESH:D011839'])
+    texts = data['texts']
+    labels = [label if label == 'HGNC:6091' else 'ungrounded'
+              for label in data['labels']]
     classifier.train(texts, labels, **params)
     feature_importances = classifier.feature_importances()
     assert isinstance(feature_importances, dict)

--- a/adeft/tests/test_classify.py
+++ b/adeft/tests/test_classify.py
@@ -65,6 +65,22 @@ def test_cv_binary():
     assert classifier.stats['precision']['mean'] > 0.5
 
 
+@attr('slow')
+def test_feature_importance():
+    params = {'C': 1.0,
+              'ngram_range': (1, 2),
+              'max_features': 1000}
+    classifier = AdeftClassifier('IR', ['HGNC:6091', 'MESH:D011839'])
+    texts = data['texts']
+    labels = data['labels']
+    classifier.train(texts, labels, **params)
+    feature_importances = classifier.feature_importances()
+    assert isinstance(feature_importances, dict)
+    assert set(feature_importances.keys()) == set(labels)
+    for label, importances in feature_importances.items():
+        assert importances == sorted(importances, key=lambda x: -x[1])
+
+
 def test_serialize():
     """Test that models can correctly be saved to and loaded from gzipped json
     """

--- a/adeft/tests/test_classify.py
+++ b/adeft/tests/test_classify.py
@@ -86,6 +86,13 @@ def test_feature_importance_multiclass():
                    isinstance(x[0], str) and
                    isinstance(x[1], float)
                    for x in importances)
+    # check if selected important features have positive score
+    assert all([score > 0 for feature, score
+                in feature_importances['HGNC:6091']
+                if feature in ['irs1', 'igf1r', 'phosphorylation']])
+    assert all([score > 0 for feature, score
+                in feature_importances['MESH:D011839']
+                if feature in ['radiation', 'exposure', 'ir induced']])
 
 
 @attr('slow')
@@ -93,7 +100,7 @@ def test_feature_importance_binary():
     params = {'C': 1.0,
               'ngram_range': (1, 2),
               'max_features': 1000}
-    classifier = AdeftClassifier('IR', ['HGNC:6091', 'MESH:D011839'])
+    classifier = AdeftClassifier('IR', ['HGNC:6091'])
     texts = data['texts']
     labels = [label if label == 'HGNC:6091' else 'ungrounded'
               for label in data['labels']]
@@ -110,6 +117,10 @@ def test_feature_importance_binary():
                    isinstance(x[0], str) and
                    isinstance(x[1], float)
                    for x in importances)
+    # check if selected important features have positive score
+    assert all([score > 0 for feature, score
+                in feature_importances['HGNC:6091']
+                if feature in ['irs1', 'igf1r', 'phosphorylation']])
 
 
 def test_serialize():

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -26,7 +26,7 @@ author = 'Albert Steppi'
 # The short X.Y version
 version = '0.5'
 # The full version, including alpha/beta/rc tags
-release = '0.5.3'
+release = '0.5.4'
 
 
 # -- General configuration ---------------------------------------------------

--- a/notebooks/model_building.ipynb
+++ b/notebooks/model_building.ipynb
@@ -416,9 +416,9 @@
        "  'MESH:D015427': 44,\n",
        "  'MESH:D007259': 11,\n",
        "  'ungrounded': 6},\n",
-       " 'f1': {'mean': 0.917901125103211, 'std': 0.02149941046150522},\n",
-       " 'precision': {'mean': 0.9037141279963776, 'std': 0.035085543153382574},\n",
-       " 'recall': {'mean': 0.9369770580296896, 'std': 0.04599217210517183}}"
+       " 'f1': {'mean': 0.9134056318688561, 'std': 0.02844464609296887},\n",
+       " 'precision': {'mean': 0.8896629543952018, 'std': 0.03442200019824876},\n",
+       " 'recall': {'mean': 0.9426450742240217, 'std': 0.038024603397752606}}"
       ]
      },
      "execution_count": 15,
@@ -446,7 +446,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'mean_fit_time': array([0.91717086, 0.99582887]), 'std_fit_time': array([0.03181937, 0.01008764]), 'mean_score_time': array([0.26613083, 0.26241016]), 'std_score_time': array([0.02430594, 0.01413601]), 'param_logit__C': masked_array(data=[10.0, 10.0],\n",
+      "{'mean_fit_time': array([1.06328301, 1.2276289 ]), 'std_fit_time': array([0.03474098, 0.02467952]), 'mean_score_time': array([0.27371278, 0.28206949]), 'std_score_time': array([0.01921871, 0.01977888]), 'param_logit__C': masked_array(data=[10.0, 10.0],\n",
       "             mask=[False, False],\n",
       "       fill_value='?',\n",
       "            dtype=object), 'param_tfidf__max_features': masked_array(data=[100, 1000],\n",
@@ -455,13 +455,80 @@
       "            dtype=object), 'param_tfidf__ngram_range': masked_array(data=[(1, 2), (1, 2)],\n",
       "             mask=[False, False],\n",
       "       fill_value='?',\n",
-      "            dtype=object), 'params': [{'logit__C': 10.0, 'tfidf__max_features': 100, 'tfidf__ngram_range': (1, 2)}, {'logit__C': 10.0, 'tfidf__max_features': 1000, 'tfidf__ngram_range': (1, 2)}], 'split0_test_f1': array([0.94970414, 0.90706578]), 'split1_test_f1': array([0.90154191, 0.95087719]), 'split2_test_f1': array([0.92341724, 0.91220909]), 'split3_test_f1': array([0.88764769, 0.87219096]), 'split4_test_f1': array([0.92719465, 0.92561404]), 'mean_test_f1': array([0.91790113, 0.91359141]), 'std_test_f1': array([0.02149941, 0.02566424]), 'rank_test_f1': array([1, 2], dtype=int32), 'split0_test_pr': array([0.92687559, 0.92077581]), 'split1_test_pr': array([0.93859649, 0.93092105]), 'split2_test_pr': array([0.93092105, 0.88039474]), 'split3_test_pr': array([0.85736842, 0.83442692]), 'split4_test_pr': array([0.86480908, 0.88233806]), 'mean_test_pr': array([0.90371413, 0.88977131]), 'std_test_pr': array([0.03508554, 0.03423669]), 'rank_test_pr': array([1, 2], dtype=int32), 'split0_test_rc': array([0.97435897, 0.8974359 ]), 'split1_test_rc': array([0.86842105, 0.97368421]), 'split2_test_rc': array([0.92105263, 0.94736842]), 'split3_test_rc': array([0.92105263, 0.92105263]), 'split4_test_rc': array([1.        , 0.97368421]), 'mean_test_rc': array([0.93697706, 0.94264507]), 'std_test_rc': array([0.04599217, 0.02986392]), 'rank_test_rc': array([2, 1], dtype=int32)}\n"
+      "            dtype=object), 'params': [{'logit__C': 10.0, 'tfidf__max_features': 100, 'tfidf__ngram_range': (1, 2)}, {'logit__C': 10.0, 'tfidf__max_features': 1000, 'tfidf__ngram_range': (1, 2)}], 'split0_test_f1': array([0.9380745 , 0.90706578]), 'split1_test_f1': array([0.90154191, 0.95087719]), 'split2_test_f1': array([0.92341724, 0.89781103]), 'split3_test_f1': array([0.88764769, 0.87219096]), 'split4_test_f1': array([0.91372549, 0.93908319]), 'mean_test_f1': array([0.91288137, 0.91340563]), 'std_test_f1': array([0.01738812, 0.02844465]), 'rank_test_f1': array([2, 1], dtype=int32), 'split0_test_pr': array([0.90567766, 0.92077581]), 'split1_test_pr': array([0.93859649, 0.93092105]), 'split2_test_pr': array([0.93092105, 0.87578947]), 'split3_test_pr': array([0.85736842, 0.83442692]), 'split4_test_pr': array([0.86074561, 0.88640152]), 'mean_test_pr': array([0.89866185, 0.88966295]), 'std_test_pr': array([0.03413925, 0.034422  ]), 'rank_test_pr': array([1, 2], dtype=int32), 'split0_test_rc': array([0.97435897, 0.8974359 ]), 'split1_test_rc': array([0.86842105, 0.97368421]), 'split2_test_rc': array([0.92105263, 0.92105263]), 'split3_test_rc': array([0.92105263, 0.92105263]), 'split4_test_rc': array([0.97368421, 1.        ]), 'mean_test_rc': array([0.9317139 , 0.94264507]), 'std_test_rc': array([0.0395308, 0.0380246]), 'rank_test_rc': array([2, 1], dtype=int32)}\n"
      ]
     }
    ],
    "source": [
     "grid_search = classifier.grid_search\n",
     "print(grid_search.cv_results_)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Feature Importances\n",
+    "A method exists to calculate feature importance scores for each label"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fi = classifier.feature_importances()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`classifier.feature_importances` returns a dictionary mapping class labels to lists of (feature, importance score) pairs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The top ten features for the label insulin receptor (HGNC:6091) are shown below"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[('insulin', 2.195052282649543),\n",
+       " ('igf', 0.8345322483241384),\n",
+       " ('cells', 0.45547628099241483),\n",
+       " ('tyrosine', 0.3659155751988399),\n",
+       " ('igf1r', 0.3213011326234487),\n",
+       " ('mice', 0.23063089000486342),\n",
+       " ('signaling', 0.18757627695380352),\n",
+       " ('stem', 0.1594544549412224),\n",
+       " ('1b', 0.15339853855716293),\n",
+       " ('phosphorylation', 0.15160167495103175)]"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fi['HGNC:6091'][0:10]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "These scores can help us interpret what information the classifier is using to make its predictions. A feature importance score is a standardized logistic regression coefficient. It is equal to the change in the linear predictor corresponding to a one standard deviation change in the associated feature value."
    ]
   },
   {
@@ -1093,7 +1160,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,

--- a/setup.py
+++ b/setup.py
@@ -28,13 +28,13 @@ if USE_CYTHON:
                            compiler_directives={'language_level': 3})
 
 setup(name='adeft',
-      version='0.5.3',
+      version='0.5.4',
       description=('Acromine based Disambiguation of Entities From'
                    ' Text'),
       long_description=long_description,
       long_description_content_type='text/markdown',
       url='https://github.com/indralab/adeft',
-      download_url='https://github.com/indralab/adeft/archive/0.5.1.tar.gz',
+      download_url='https://github.com/indralab/adeft/archive/0.5.4.tar.gz',
       author='adeft developers, Harvard Medical School',
       author_email='albert_steppi@hms.harvard.edu',
       classifiers=[


### PR DESCRIPTION
This PR adds a method to the AdeftClassifier that allows for the calculation of feature importance scores. Feature importance scores are standardized logistic regression coefficients. The score for a feature is equal to the change in the linear predictor corresponding to a one standard deviation change in the feature value. To allow for this computation, the AdeftClassifier must now store an array of the standard deviations of all training features (features are tf-idf vectorized n-grams). This standard deviation array is now included when an AdeftClassifier is serialized. Care was taken to ensure models remain forwards and backwards compatible with respect to this change.