### PR TITLE
Bug fixes and updates

### DIFF
--- a/adeft/discover.py
+++ b/adeft/discover.py
@@ -549,7 +549,7 @@ class AdeftMiner(object):
                     child = None
                 current.children = {}
                 continue
-            for stack in current.children.values():
+            for child in current.children.values():
                 stack.append((child, depth + 1))
 
     def _add(self, tokens):

--- a/adeft/download/__main__.py
+++ b/adeft/download/__main__.py
@@ -6,7 +6,7 @@ from adeft.download import setup_models_folder, setup_test_resource_folder
 
 # Create .adeft folder if it does not already exist
 if not os.path.exists(ADEFT_PATH):
-    os.mkdir(ADEFT_PATH)
+    os.makedirs(ADEFT_PATH)
 
 setup_models_folder()
 setup_test_resource_folder()

--- a/adeft/gui/__init__.py
+++ b/adeft/gui/__init__.py
@@ -10,6 +10,7 @@ import tempfile
 import webbrowser
 from multiprocessing import Process
 
+
 logger = logging.getLogger(__name__)
 
 
@@ -99,7 +100,7 @@ def ground_with_gui(longforms, scores, grounding_map=None,
                      verbose, test=test)
 
     # Run flask server in new process
-    flask_server = Process(target=lambda: app.run(port=port))
+    flask_server = Process(target=_run_app, args=(app, port))
     flask_server.start()
     # Open app in browser unless a test is being run
     if not test and not no_browser:
@@ -122,3 +123,7 @@ def ground_with_gui(longforms, scores, grounding_map=None,
     names = output['names']
     pos_labels = output['pos_labels']
     return grounding_map, names, pos_labels
+
+
+def _run_app(app, port):
+    return app.run(port=port)

--- a/adeft/locations.py
+++ b/adeft/locations.py
@@ -1,8 +1,12 @@
 import os
 from adeft import __version__
 
-ADEFT_PATH = os.path.join(os.path.expanduser('~'), '.adeft_%s' % __version__)
 
+ADEFT_HOME = os.environ.get('ADEFT_HOME')
+if ADEFT_HOME is None:
+    ADEFT_HOME = os.path.join(os.path.expanduser('~'), '.adeft')
+
+ADEFT_PATH = os.path.join(ADEFT_HOME, __version__)
 ADEFT_MODELS_PATH = os.path.join(ADEFT_PATH, 'models')
 RESOURCES_PATH = os.path.join(ADEFT_PATH, 'resources')
 TEST_RESOURCES_PATH = os.path.join(ADEFT_PATH, 'test_resources')

--- a/adeft/locations.py
+++ b/adeft/locations.py
@@ -15,6 +15,5 @@ if ADEFT_HOME is None:
 
 ADEFT_PATH = os.path.join(ADEFT_HOME, __version__)
 ADEFT_MODELS_PATH = os.path.join(ADEFT_PATH, 'models')
-RESOURCES_PATH = os.path.join(ADEFT_PATH, 'resources')
 TEST_RESOURCES_PATH = os.path.join(ADEFT_PATH, 'test_resources')
 S3_BUCKET_URL = os.path.join('http://adeft.s3.amazonaws.com', __version__)

--- a/adeft/locations.py
+++ b/adeft/locations.py
@@ -1,3 +1,10 @@
+"""
+Contains paths to locations on user's system where models and resources are
+to be stored. These all live in adeft's home folder which defaults to the
+hidden directory ".adeft" in the user's home directory but which can be
+specified by setting the environment variable ADEFT_HOME in the user's profile.
+"""
+
 import os
 from adeft import __version__
 

--- a/adeft/modeling/classify.py
+++ b/adeft/modeling/classify.py
@@ -238,7 +238,7 @@ class AdeftClassifier(object):
         # Fit grid_search and set the estimator for the instance of the class
         grid_search = GridSearchCV(logit_pipeline, param_grid,
                                    cv=cv, n_jobs=n_jobs, scoring=scorer,
-                                   refit='f1_weighted', iid=False,
+                                   refit='f1_weighted',
                                    return_train_score=False)
         grid_search.fit(texts, y)
         logger.info('Best f1 score of %s found for' % grid_search.best_score_

--- a/adeft/modeling/classify.py
+++ b/adeft/modeling/classify.py
@@ -191,7 +191,7 @@ class AdeftClassifier(object):
         # initialized. Uses the average of the f1 scores for each positive
         # label weighted by the frequency in which it appears in the training
         # data.
-        if len(self.pos_labels) > 1:
+        if len(set(y)) > 2 or len(self.pos_labels) > 1:
             weighted_f1_scorer = make_scorer(f1_score, labels=self.pos_labels,
                                              average='weighted')
             weighted_pr_scorer = make_scorer(precision_score,

--- a/adeft/modeling/classify.py
+++ b/adeft/modeling/classify.py
@@ -101,7 +101,8 @@ class AdeftClassifier(object):
         self.timestamp = None
         self.training_set_digest = None
 
-    def train(self, texts, y, C=1.0, ngram_range=(1, 2), max_features=1000):
+    def train(self, texts, y, C=1.0, ngram_range=(1, 2), max_features=1000,
+              class_weight=None):
         """Fits a disambiguation model
 
         Parameters
@@ -121,24 +122,36 @@ class AdeftClassifier(object):
         max_features : int
             Maximum number of tfidf-vectorized ngrams to use as features in
             model. Selects top_features by term frequency Default: 1000
+        class_weight : Optional[dict or 'balanced']
+            Weights associated with classes in the form {class_label:
+            weight}. If not given, all classes are supposed to have weight one.
+
+            The “balanced” mode uses the values of y to automatically adjust
+            weights inversely proportional to class frequencies in the input
+            data as n_samples / (n_classes * np.bincount(y)).
+
+            Note that these weights will be multiplied with sample_weight
+            (passed through the fit method) if sample_weight is specified.
         """
         # Initialize pipeline
         seed = self.random_state
-        logit_pipeline = Pipeline([('tfidf',
-                                    TfidfVectorizer(ngram_range=ngram_range,
-                                                    max_features=max_features,
-                                                    stop_words=self.stop)),
-                                   ('logit',
-                                    LogisticRegression(C=C,
-                                                       solver='saga',
-                                                       penalty='l1',
-                                                       multi_class='auto',
-                                                       random_state=seed))])
-
+        logit_pipeline = \
+            Pipeline([('tfidf',
+                       TfidfVectorizer(ngram_range=ngram_range,
+                                       max_features=max_features,
+                                       stop_words=self.stop)),
+                      ('logit',
+                       LogisticRegression(C=C,
+                                          solver='saga',
+                                          penalty='l1',
+                                          multi_class='auto',
+                                          class_weight=class_weight,
+                                          random_state=seed))])
         logit_pipeline.fit(texts, y)
 
         self.params = {'C': C, 'ngram_grange': ngram_range,
                        'max_features': max_features,
+                       'class_weight': class_weight,
                        'random_state': self.random_state}
         self.estimator = logit_pipeline
         self.best_score = None
@@ -226,6 +239,7 @@ class AdeftClassifier(object):
                     '%s' % param_grid)
 
         param_mapping = {'C': 'logit__C',
+                         'class_weight': 'logit__class_weight',
                          'max_features': 'tfidf__max_features',
                          'ngram_range':  'tfidf__ngram_range'}
         inverse_param_mapping = {value: key

--- a/adeft/modeling/label.py
+++ b/adeft/modeling/label.py
@@ -23,32 +23,38 @@ class AdeftLabeler(object):
                             for shortform, grounding_map
                             in grounding_dict.items()]
 
-    def build_from_texts(self, texts):
+    def build_from_texts(self, text_tuples):
         """Build labeled corpus from a list of texts
 
         Labels texts based on defining patterns (DPs)
 
         Parameters
         ----------
-        texts : list of str
-            List of texts to build corpus from
+        text_tuples : list of tuple
+            List of two element tuples whose first elements are texts from
+            which we seek to build a corpus and whose second elements are
+            identifiers associated with the texts. Each text should have a
+            unique identifier associated to it.
 
         Returns
         -------
-        corpus : list of tuple
-            Contains tuples for each text in the input list which contains
+        corpus : list
+            Contains a tuple for each text in the input list which contains
             a defining pattern. Multiple tuples correspond to texts with
             multiple defining patterns for longforms with different groundings.
-            The first element of each tuple contains the training text with all
+            The first element of each tuple contains a training text with all
             defining patterns replaced with only the shortform. The second
-            element contains the groundings for longforms matched with a
-            defining pattern.
+            element contains a grounding label for the desired shortform within
+            the training text that was identified through a defining
+            pattern. The third element contains the identifier for the given
+            training text.
         """
         corpus = []
-        for text in texts:
+        for text, identifier in text_tuples:
             data_points = self._process_text(text)
             if data_points:
-                corpus.extend(data_points)
+                corpus.extend((*data_point, identifier)
+                              for data_point in data_points)
         return corpus
 
     def _process_text(self, text):

--- a/adeft/score/score.py
+++ b/adeft/score/score.py
@@ -1,5 +1,5 @@
 import math
-import string
+from unicodedata import category
 
 from adeft.nlp import stopwords_min
 from adeft.score._score import score, optimize_alignment
@@ -10,8 +10,7 @@ class AlignmentBasedScorer(object):
                  alpha=0.2, beta=0.95, gamma=0.95, delta=1.0,
                  epsilon=0.4, lambda_=0.6, rho=0.95, zeta=0.9,
                  word_scores=None, inversions_cap=16):
-        self.shortform = ''.join(char for char in shortform.lower()
-                                 if char not in string.punctuation)
+        self.shortform = shortform.lower()
         self.alpha = alpha
         self.beta = beta
         self.gamma = gamma
@@ -34,7 +33,12 @@ class AlignmentBasedScorer(object):
         if penalties is not None:
             self.penalties = penalties
         else:
-            self.penalties = [delta*epsilon**i for i in range(len(shortform))]
+            # Punctuation and space characters have no penalty
+            self.penalties = [delta*epsilon**i
+                              if not (category(char).startswith('Z') or
+                                      category(char).startswith('C'))
+                              else 0.0
+                              for i, char in enumerate(shortform)]
         if word_scores is None:
             self.word_scores = {word: 0.2 for word in stopwords_min}
         else:

--- a/adeft/tests/test_corpora.py
+++ b/adeft/tests/test_corpora.py
@@ -64,9 +64,10 @@ labels3 = set(['other indra'])
 
 text4 = 'We cannot determine what INDRA means from this sentence.'
 
-result_corpus = [(result[0], label) for result in [(result1, labels1),
-                                                   (result2, labels2),
-                                                   (result3, labels3)]
+result_corpus = [(result[0], label, i)
+                 for i, result in enumerate([(result1, labels1),
+                                             (result2, labels2),
+                                             (result3, labels3)])
                  for label in result[1]]
 
 #  content for corpus building with synomous shortforms
@@ -93,9 +94,10 @@ text7 = ('Nanoparticle (NP) PET/CT imaging of natriuretic peptide (NP)'
 result7 = ('NP PET/CT imaging of NP clearance receptor in prostate cancer.')
 labels7 = set(['nano', 'peptide'])
 
-result_corpus2 = [(result[0], label) for result in [(result5, labels5),
-                                                    (result6, labels6),
-                                                    (result7, labels7)]
+result_corpus2 = [(result[0], label, i) for
+                  i, result in enumerate([(result5, labels5),
+                                          (result6, labels6),
+                                          (result7, labels7)])
                   for label in result[1]]
 
 
@@ -126,11 +128,16 @@ def test__process_text_multiple():
 
 def test_build_from_texts():
     labeler = AdeftLabeler({'INDRA': longforms})
-    corpus = labeler.build_from_texts([text1, text2, text3, text4])
+    corpus = labeler.build_from_texts([(text1, 0),
+                                       (text2, 1),
+                                       (text3, 2),
+                                       (text4, 3)])
     assert set(corpus) == set(result_corpus)
 
 
 def test__build_from_texts_multiple():
     labeler = AdeftLabeler({'NP': groundings1, 'NPs': groundings2})
-    corpus = labeler.build_from_texts([text5, text6, text7])
+    corpus = labeler.build_from_texts([(text5, 0),
+                                       (text6, 1),
+                                       (text7, 2)])
     assert set(corpus) == set(result_corpus2)

--- a/adeft/tests/test_discover.py
+++ b/adeft/tests/test_discover.py
@@ -140,3 +140,14 @@ def test_compose_adeft_miners():
     combined = compose(miner1, miner2)
     print(combined)
     assert combined.top() == miner3.top()
+
+
+def test_prune():
+    miner = AdeftMiner('INDRA')
+    miner.process_texts([example_text1, example_text2,
+                         example_text3, example_text4])
+    candidates = [candidate for candidate, _, _ in miner.top()]
+    miner.prune(5)
+    pruned_candidates = [candidate for candidate, _, _ in miner.top()]
+    assert pruned_candidates == [candidate for candidate in candidates if
+                                 len(candidate.split()) <= 5]

--- a/notebooks/model_building.ipynb
+++ b/notebooks/model_building.ipynb
@@ -250,7 +250,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -272,7 +272,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -288,7 +288,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -309,7 +309,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -322,12 +322,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Texts for model training are labeled using the ``AdeftLabeler.build_from_texts`` method. The output, ``corpus``, contains a list of two-element tuples of which the first element is a text and the second element is a label taken from the values of the grounding map. "
+    "Texts for model training are labeled using the ``AdeftLabeler.build_from_texts`` method. The input should be a list like of tuples of the form (text, identifier). The output, ``corpus``, contains a list of three-element tuples of which the first element is a text with all defining patterns stripped out, the second element is a label taken from the values of the grounding map and the third element is identifier associated to the text in the input. Each text should have a unique identifier. The identifiers are useful for mapping texts in the output corpus back to texts in the input. Texts without defining patterns will be filtered out and those with defining patterns will be modified by replacing the defining patterns with only the shortform, making it nontrivial to map back without the identifiers."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 12,
    "metadata": {
     "scrolled": true
    },
@@ -342,7 +342,7 @@
     }
    ],
    "source": [
-    "corpus = labeler.build_from_texts(ir_texts)\n",
+    "corpus = labeler.build_from_texts([(text, identifier) for identifier, text in enumerate(ir_texts)])\n",
     "print(\"corpus[0][0]: %s...\" % corpus[0][0][0:70])\n",
     "print(\"corpus[0][1]: %s\" % str(corpus[0][1]))"
    ]
@@ -356,19 +356,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "340\n"
+      "339\n"
      ]
     }
    ],
    "source": [
-    "texts, labels = zip(*corpus)\n",
+    "texts, labels, identifiers = zip(*corpus)\n",
     "\n",
     "print(len(texts))"
    ]
@@ -389,7 +389,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -408,7 +408,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -444,7 +444,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -462,46 +462,42 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'label_distribution': {'MESH:D007333': 88,\n",
+       "{'label_distribution': {'MESH:D007333': 87,\n",
        "  'MESH:D011839': 121,\n",
        "  'HGNC:6091': 70,\n",
        "  'MESH:D015427': 44,\n",
        "  'MESH:D007259': 11,\n",
        "  'ungrounded': 6},\n",
-       " 'f1': {'mean': 0.9200852258980541, 'std': 0.042655728178053645},\n",
-       " 'precision': {'mean': 0.885850272232305, 'std': 0.053313635138337305},\n",
-       " 'recall': {'mean': 0.9581646423751687, 'std': 0.035620884343110074},\n",
-       " 'ungrounded': {'f1': {'mean': 0.0, 'std': 0.0},\n",
-       "  'pr': {'mean': 0.0, 'std': 0.0},\n",
-       "  'rc': {'mean': 0.0, 'std': 0.0}},\n",
-       " 'MESH:D015427': {'f1': {'mean': 0.967251461988304,\n",
-       "   'std': 0.04416656745847769},\n",
-       "  'pr': {'mean': 0.9777777777777779, 'std': 0.04444444444444447},\n",
-       "  'rc': {'mean': 0.9577777777777777, 'std': 0.05183068350973601}},\n",
-       " 'HGNC:6091': {'f1': {'mean': 0.876288998357964, 'std': 0.08288334751032712},\n",
-       "  'pr': {'mean': 0.9, 'std': 0.07284313590846837},\n",
-       "  'rc': {'mean': 0.8548809523809524, 'std': 0.09599136629732968}},\n",
-       " 'MESH:D011839': {'f1': {'mean': 0.945338846649771,\n",
-       "   'std': 0.02202026685744435},\n",
-       "  'pr': {'mean': 0.9916666666666668, 'std': 0.016666666666666653},\n",
-       "  'rc': {'mean': 0.9037300324196875, 'std': 0.03423999190136251}},\n",
-       " 'MESH:D007333': {'f1': {'mean': 0.9033986928104575,\n",
-       "   'std': 0.061948097209131685},\n",
-       "  'pr': {'mean': 0.8640522875816993, 'std': 0.09295303418469995},\n",
-       "  'rc': {'mean': 0.951388888888889, 'std': 0.046481112585226414}},\n",
-       " 'MESH:D007259': {'f1': {'mean': 0.8333333333333334,\n",
-       "   'std': 0.21081851067789195},\n",
-       "  'pr': {'mean': 0.7666666666666666, 'std': 0.2905932629027116},\n",
-       "  'rc': {'mean': 1.0, 'std': 0.0}}}"
+       " 'f1': {'mean': 0.920783, 'std': 0.022582},\n",
+       " 'precision': {'mean': 0.903594, 'std': 0.041701},\n",
+       " 'recall': {'mean': 0.942375, 'std': 0.042142},\n",
+       " 'MESH:D007259': {'f1': {'mean': 0.346667, 'std': 0.299333},\n",
+       "  'pr': {'mean': 0.266667, 'std': 0.226078},\n",
+       "  'rc': {'mean': 0.5, 'std': 0.447214}},\n",
+       " 'MESH:D011839': {'f1': {'mean': 0.952425, 'std': 0.028773},\n",
+       "  'pr': {'mean': 0.975, 'std': 0.020412},\n",
+       "  'rc': {'mean': 0.933333, 'std': 0.059259}},\n",
+       " 'HGNC:6091': {'f1': {'mean': 0.866005, 'std': 0.068818},\n",
+       "  'pr': {'mean': 0.885714, 'std': 0.09689},\n",
+       "  'rc': {'mean': 0.852259, 'std': 0.069444}},\n",
+       " 'ungrounded': {'f1': {'mean': 0.133333, 'std': 0.266667},\n",
+       "  'pr': {'mean': 0.2, 'std': 0.4},\n",
+       "  'rc': {'mean': 0.1, 'std': 0.2}},\n",
+       " 'MESH:D007333': {'f1': {'mean': 0.862796, 'std': 0.026696},\n",
+       "  'pr': {'mean': 0.861438, 'std': 0.059853},\n",
+       "  'rc': {'mean': 0.872741, 'std': 0.073905}},\n",
+       " 'MESH:D015427': {'f1': {'mean': 0.945029, 'std': 0.049704},\n",
+       "  'pr': {'mean': 0.955556, 'std': 0.054433},\n",
+       "  'rc': {'mean': 0.935556, 'std': 0.052775}}}"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1253,7 +1249,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.8.5"
   },
   "name": "model_building.ipynb"
  },


### PR DESCRIPTION
This PR makes fixes several bugs and makes some small updates.

Fixes have been made for

1. A bug in `AdeftMiner.prune` that broke this method but was undiscovered due to lack of testing. The bug has been fixed and a test has been added.
2. Training adeft models throwing an error for the edge case where there are more than two labels with only one positive label.
3. The longform scorer throwing an error when there are punctuation characters in the shortform.
4. The GUI not working when the multiprocessing start method is set to spawn. This caused the GUI to fail on windows, where fork is unavailable. This should resolve issue #49 
5. The deprecated parameter `iid` has been removed from internal use of Scikit-learn's `GridSearchCV`, removing a deprecation warning.

.The following other changes have been made

1. AdeftLabeler now requires unique identifiers along with the texts passed into process_texts. Instead of passing in a list of texts, the process_texts method now takes a list of tuples of the form (text, identifier). The output list now contains tuples of the form (text, label, identifier). This is useful for mapping back from texts in the generated corpus to texts in the input. Texts without defining patterns are filtered out completely and those with defining patterns have the defining patterns replaced with only the shortform, making mapping backwards nontrivial without the identifiers.
2. Adeft's home folder can now be specified by setting the environment variable `ADEFT_HOME` in the user's profile. The default is now the hidden folder ".adeft" in the users home directory with subfolders for different adeft versions.
3. The parameter `class_weight` from Scikit-learn's implementation of logistic regression is now exposed as a parameter of `AdeftClassifier`. This allows for provided different weights in the loss function for different class labels.
