### PR TITLE
Labels and stats

### DIFF
--- a/adeft/disambiguate.py
+++ b/adeft/disambiguate.py
@@ -2,8 +2,10 @@
 
 import os
 import json
-from hashlib import md5
 import logging
+import numpy as np
+from hashlib import md5
+
 
 from adeft.locations import ADEFT_MODELS_PATH
 from adeft.recognize import AdeftRecognizer
@@ -133,6 +135,48 @@ class AdeftDisambiguator(object):
                 result[index] = (disamb, self.names.get(disamb), pred)
                 pred_index += 1
         return result
+
+    def update_pos_labels(self, pos_labels):
+        """Update which labels are considered pos_labels
+
+        Micro-averaged precision, recall, and f1 scores are also updated.
+
+        Parameters
+        ----------
+        pos_labels : list
+            list of strs. Should be a subset of the labels produced by the
+            underlying classifier. Check the labels attribute of the
+            AdeftDisambiguator to see which labels are produced.
+        """
+        self.pos_labels = pos_labels
+        labels = list(self.labels)
+        confusion = self.classifier.confusion_info
+        num_splits = len(confusion[labels[0]][labels[0]])
+        TP = np.zeros(num_splits, dtype=int)
+        FP = np.zeros(num_splits, dtype=int)
+        FN = np.zeros(num_splits, dtype=int)
+        for label1 in self.labels:
+            for label2 in self.labels:
+                row = np.array(confusion[label1][label2])
+                if label1 == label2 and label1 in pos_labels:
+                    TP += row
+                if label1 != label2 and label1 in pos_labels:
+                    FN += row
+                if label1 != label2 and label2 in pos_labels:
+                    FP += row
+        Pr = TP/(TP + FP)
+        Rc = TP/(TP + FN)
+        Pr[Pr == np.float('inf')] = 0.
+        Rc[Rc == np.float('inf')] = 0.
+        F1 = 2/(1/Pr + 1/Rc)
+        stats = self.classifier.stats
+        stats['f1']['mean'] = np.round(np.mean(F1), 6)
+        stats['f1']['std'] = np.round(np.std(F1), 6)
+        stats['precision']['mean'] = np.round(np.mean(Pr), 6)
+        stats['precision']['std'] = np.round(np.std(Pr), 6)
+        stats['recall']['mean'] = np.round(np.mean(Rc), 6)
+        stats['recall']['std'] = np.round(np.std(Rc), 6)
+        self.classifier.stats = stats
 
     def modify_groundings(self, new_groundings=None, new_names=None):
         """Update groundings and standardized names

--- a/adeft/disambiguate.py
+++ b/adeft/disambiguate.py
@@ -215,6 +215,10 @@ class AdeftDisambiguator(object):
                               count
                               for label, count in label_dist.items()}
                 classifier.stats['label_distribution'] = label_dist
+                classifier.stats = {new_groundings[label]
+                                    if label in new_groundings else label:
+                                    value for label, value in
+                                    classifier.stats.items()}
 
     def dump(self, model_name, path=None):
         """Save disambiguator to disk

--- a/adeft/disambiguate.py
+++ b/adeft/disambiguate.py
@@ -37,7 +37,7 @@ class AdeftDisambiguator(object):
         Set of labels that the classifier is able to predict.
     pos_labels : list of str
         List of labels of interest. Only these are considered when
-        calculating the weighted f1 score for a classifier.
+        calculating the micro averaged f1 score for a classifier.
     """
     def __init__(self, classifier, grounding_dict, names):
         self.classifier = classifier
@@ -241,7 +241,7 @@ class AdeftDisambiguator(object):
         model_path = os.path.join(path, model_name)
         # Create model directory if it does not already exist
         if not os.path.exists(model_path):
-            os.mkdir(model_path)
+            os.makedirs(model_path)
 
         classifier.dump_model(os.path.join(model_path,
                                            '%s_model.gz' % model_name))
@@ -282,10 +282,12 @@ class AdeftDisambiguator(object):
         Displays disambiguations model is able to produce. Shows class
         balance of disambiguation labels in the models training data and
         crossvalidated F1 score, precision, and recall on training data.
-        Classification metrics are given by the weighted average of these
-        metrics over positive labels, weighted by number of examples in
-        each class in test data. Positive labels are appended with stars in
-        the displayed info. Classification metrics may not be available
+        Classification metrics for multi-label data are calculated by taking
+        the micro-average over the positive labels. This means the metrics
+        are calculated globally by counting the total true positives,
+        false negatives, and false positives. Positive labels are starred in
+        in the displayed output. F1, Precision, and Recall are also shown for
+        for each label separately. Classification metrics may not be available
         depending upon how the model was trained.
 
         Returns
@@ -336,7 +338,7 @@ class AdeftDisambiguator(object):
                                           str(count).rjust(count_pad),
                                           str(f1).rjust(metric_pad))
         output += '\n'
-        output += 'Weighted Metrics:\n'
+        output += 'Global Metrics:\n'
         output += '-----------------\n'
         f1 = round(model_stats['f1']['mean'], 5)
         output += '\tF1 score:\t%s\n' % f1

--- a/adeft/modeling/classify.py
+++ b/adeft/modeling/classify.py
@@ -372,6 +372,8 @@ class AdeftClassifier(object):
             model_info['params'] = self.params
         if hasattr(self, 'version') and self.version is not None:
             model_info['version'] = self.version
+        if hasattr(self, 'confusion_info') and self.confusion_info is not None:
+            model_info['confusion_info'] = self.confusion_info
         return model_info
 
     def dump_model(self, filepath):
@@ -534,6 +536,8 @@ def load_model_info(model_info):
         longform_model.params = model_info['params']
     if 'version' in model_info:
         longform_model.version == model_info['version']
+    if 'confusion_info' in model_info:
+        longform_model.confusion_info = model_info['confusion_info']
     return longform_model
 
 

--- a/adeft/modeling/classify.py
+++ b/adeft/modeling/classify.py
@@ -76,6 +76,9 @@ class AdeftClassifier(object):
         `confusion_info[label1][label2][i]` gives the number of test examples
         where the true label is label1 and the classifier has made prediction
         label2 in split i.
+    other_metadata : dict
+        Data set here by the user will be included when the model is serialized
+        and remain available when the classifier is loaded again.
     version : str
         Adeft version used when model was fit
     timestamp : str
@@ -98,6 +101,7 @@ class AdeftClassifier(object):
         self.estimator = None
         self.stats = None
         self.confusion_info = None
+        self.other_metadata = None
         # Add shortforms to list of stopwords
         self.stop = set(english_stopwords).union([sf.lower() for sf
                                                   in self.shortforms])
@@ -374,6 +378,8 @@ class AdeftClassifier(object):
             model_info['version'] = self.version
         if hasattr(self, 'confusion_info') and self.confusion_info is not None:
             model_info['confusion_info'] = self.confusion_info
+        if hasattr(self, 'other_metadata') and self.other_metadata is not None:
+            model_info['other_metadata'] = self.other_metadata
         return model_info
 
     def dump_model(self, filepath):
@@ -538,6 +544,8 @@ def load_model_info(model_info):
         longform_model.version == model_info['version']
     if 'confusion_info' in model_info:
         longform_model.confusion_info = model_info['confusion_info']
+    if 'other_metadata' in model_info:
+        longform_model.other_metadata = model_info['other_metadata']
     return longform_model
 
 

--- a/adeft/modeling/classify.py
+++ b/adeft/modeling/classify.py
@@ -216,7 +216,7 @@ class AdeftClassifier(object):
         scorer = {'f1': f1_scorer,
                   'pr': pr_scorer,
                   'rc': rc_scorer}
-        all_labels = set(y)
+        all_labels = sorted(set(y))
         for label in all_labels:
             f1 = make_scorer(f1_score, labels=[label], average=None)
             pr = make_scorer(recall_score, labels=[label], average=None)
@@ -224,6 +224,11 @@ class AdeftClassifier(object):
             scorer.update({'f1_%s' % label: f1,
                            'pr_%s' % label: pr,
                            'rc_%s' % label: rc})
+        for label1 in all_labels:
+            for label2 in all_labels:
+                count_score = make_scorer(_count_score, label1=label1,
+                                          label2=label2)
+                scorer['count_%s_%s' % (label1, label2)] = count_score
         logger.info('Beginning grid search in parameter space:\n'
                     '%s' % param_grid)
 
@@ -512,3 +517,8 @@ def load_model_info(model_info):
     if 'version' in model_info:
         longform_model.version == model_info['version']
     return longform_model
+
+
+def _count_score(y_true, y_pred, label1=0, label2=1):
+    return sum((y == label1 and pred == label2)
+               for y, pred in zip(y_true, y_pred))

--- a/adeft/tests/test_classify.py
+++ b/adeft/tests/test_classify.py
@@ -109,6 +109,7 @@ def test_serialize():
     classifier1.dump_model(temp_filename)
 
     classifier2 = load_model(temp_filename)
+    classifier2.other_metadata = {'test': 'This is a test.'}
     classifier2.dump_model(temp_filename)
 
     classifier3 = load_model(temp_filename)
@@ -142,4 +143,5 @@ def test_serialize():
         classifier3.version
     # Check that model params are unchanged
     assert classifier1.params == classifier2.params == classifier3.params
+    assert classifier2.other_metadata == classifier3.other_metadata
     os.remove(temp_filename)

--- a/adeft/tests/test_disambiguate.py
+++ b/adeft/tests/test_disambiguate.py
@@ -104,6 +104,17 @@ def test_modify_groundings():
     assert ad.names['UP:P06213'] == 'Insulin Receptor'
 
 
+def test_update_pos_labels():
+    """Test updating of positive labels in existing model."""
+    ad1 = load_disambiguator('IR', path=TEST_MODEL_PATH)
+    ad2 = load_disambiguator('IR', path=TEST_MODEL_PATH)
+    ad2.update_pos_labels(ad1.pos_labels)
+    assert ad1.classifier.stats == ad2.classifier.stats
+    ad2.update_pos_labels(ad1.pos_labels + ['MESH:D007333'])
+    assert set(ad2.pos_labels) == set(['HGNC:6091', 'MESH:D011839',
+                                       'MESH:D007333'])
+
+
 @raises(ValueError)
 def test_modify_groundings_error():
     ad = load_disambiguator('IR', path=TEST_MODEL_PATH)


### PR DESCRIPTION
This PR makes several changes concerning model statistics. 

1. The global precision, recall, and F1 scores for a classifier now use micro-averaging to aggregate across the scores for different positive class labels rather than taking an average weighted by the frequencies for each positive label. Micro-averaging looks at global counts of true positives, false positives, and false negatives
across all positive labels. A true positive involves any positive labeled datapoint classified correctly. A false positive involves any positive labeled datapoint that has been classified incorrectly. A false negative involves any datapoint being classified incorrectly to a positive labeled datapoint. Note that false positives and false negatives can overlap. Micro-averaging is easier to reason about and interpret and using it allows for some simplification of implementation in other places. The original decision to use the weighted average was made with little thought at a time when we were making less use of model statistics.

2. A method has been added to `adeft.disambiguate.AdeftDisambiguator` that allows the set of positive labels to be updated while  recomputing global model statistics. Previously it was required to retrain the model. This is facilitated by storing the entire label vs label confusion matrix for each CV fold upon training a model and serializing this when saving the model.

A bug fix and a smaller change were also made
1. A bug was fixed that was causing the labels in model statistics to fail to update when `adeft.disambiguate.AdeftDisambiguator.modify_groundings` was used to update groundings in a model.
2. A new attribute was added to classifiers called `other_metadata`. Anything jsonable stored within this attribute will be preserved upon model serialization. This will be used internally to our team to store any additional information needed to retrain an `AdeftClassifier` that was not previously being stored