### PR TITLE
Update Pos Labels Bug Fix

### DIFF
--- a/adeft/disambiguate.py
+++ b/adeft/disambiguate.py
@@ -148,35 +148,44 @@ class AdeftDisambiguator(object):
             underlying classifier. Check the labels attribute of the
             AdeftDisambiguator to see which labels are produced.
         """
-        self.pos_labels = pos_labels
         labels = list(self.labels)
-        confusion = self.classifier.confusion_info
-        num_splits = len(confusion[labels[0]][labels[0]])
-        TP = np.zeros(num_splits, dtype=int)
-        FP = np.zeros(num_splits, dtype=int)
-        FN = np.zeros(num_splits, dtype=int)
-        for label1 in self.labels:
-            for label2 in self.labels:
-                row = np.array(confusion[label1][label2])
-                if label1 == label2 and label1 in pos_labels:
-                    TP += row
-                if label1 != label2 and label1 in pos_labels:
-                    FN += row
-                if label1 != label2 and label2 in pos_labels:
-                    FP += row
-        Pr = TP/(TP + FP)
-        Rc = TP/(TP + FN)
-        Pr[Pr == np.float('inf')] = 0.
-        Rc[Rc == np.float('inf')] = 0.
-        F1 = 2/(1/Pr + 1/Rc)
         stats = self.classifier.stats
-        stats['f1']['mean'] = np.round(np.mean(F1), 6)
-        stats['f1']['std'] = np.round(np.std(F1), 6)
-        stats['precision']['mean'] = np.round(np.mean(Pr), 6)
-        stats['precision']['std'] = np.round(np.std(Pr), 6)
-        stats['recall']['mean'] = np.round(np.mean(Rc), 6)
-        stats['recall']['std'] = np.round(np.std(Rc), 6)
+        confusion = self.classifier.confusion_info
+        if stats is not None and confusion is not None:
+            num_splits = len(confusion[labels[0]][labels[0]])
+            TP = np.zeros(num_splits, dtype=int)
+            FP = np.zeros(num_splits, dtype=int)
+            FN = np.zeros(num_splits, dtype=int)
+            for label1 in self.labels:
+                for label2 in self.labels:
+                    row = np.array(confusion[label1][label2])
+                    if label1 == label2 and label1 in pos_labels:
+                        TP += row
+                    if label1 != label2 and label1 in pos_labels:
+                        FN += row
+                    if label1 != label2 and label2 in pos_labels:
+                        FP += row
+            Pr = TP/(TP + FP)
+            Rc = TP/(TP + FN)
+            Pr[Pr == np.float('inf')] = 0.
+            Rc[Rc == np.float('inf')] = 0.
+            F1 = 2/(1/Pr + 1/Rc)
+            stats['f1']['mean'] = np.round(np.mean(F1), 6)
+            stats['f1']['std'] = np.round(np.std(F1), 6)
+            stats['precision']['mean'] = np.round(np.mean(Pr), 6)
+            stats['precision']['std'] = np.round(np.std(Pr), 6)
+            stats['recall']['mean'] = np.round(np.mean(Rc), 6)
+            stats['recall']['std'] = np.round(np.std(Rc), 6)
+        elif (stats is not None and
+              set(pos_labels) != set(self.pos_labels)):
+            stats['f1']['mean'] = float('nan')
+            stats['f1']['std'] = float('nan')
+            stats['precision']['mean'] = float('nan')
+            stats['precision']['std'] = float('nan')
+            stats['recall']['mean'] = float('nan')
+            stats['recall']['std'] = float('nan')
         self.classifier.stats = stats
+        self.pos_labels = pos_labels
 
     def modify_groundings(self, new_groundings=None, new_names=None):
         """Update groundings and standardized names


### PR DESCRIPTION
This PR fixes a bug in the method to update the positive labels in an `adeft.disambiguate.AdeftDisambiguator` while making the corresponding adjustments in global statistics without retraining. The previous implementation failed in the case where statistics are not available or for older models where the confusion matrix has not been stored.