### PR TITLE
Streamline testing with tox

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,10 +17,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: |
-          pip install .[test]
-          python setup.py build_ext --inplace
-          python -m adeft.download
+        run:
+          pip install tox
       - name: Test with nose
         run:
-          nosetests adeft -v --with-coverage --cover-inclusive --cover-package=adeft
+          tox

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,6 @@ jobs:
       - name: Install dependencies
         run:
           pip install tox
-      - name: Test with nose
+      - name: Test with Tox
         run:
           tox

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ er_dd = load_disambiguator('ER')
 er_dd.disambiguate(texts)
 ```
 
-Users may also build and train their own disambiguators. See the documention
+Users may also build and train their own disambiguators. See the documentation
 for more info.
 
 
@@ -82,16 +82,14 @@ Jupyter notebooks illustrating Adeft workflows are available under `notebooks`:
 
 ## Testing
 
-Adeft uses `nosetests` for unit testing, and is integrated with the Travis
-continuous integration environment. To run tests locally, make sure
-to install the test-specific requirements listed in setup.py as
+Adeft uses `tox` to automate unit testing, and is integrated with the GitHub Actions
+continuous integration environment. To run unit tests locally, simply
+install and run `tox` with the following:
 
 ```bash
-pip install adeft[test]
+$ pip install tox
+$ tox
 ```
-
-and download all pre-trained models as shown above.
-Then run `nosetests` in the top-level `adeft` folder.
 
 ## Funding
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,10 @@
+[tox]
+envlist =
+    py
+
+[testenv]
+commands =
+    python setup.py build_ext --inplace
+    nosetests adeft -v --with-coverage --cover-inclusive --cover-package=adeft
+extras =
+    test

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
 [testenv]
 commands =
     python setup.py build_ext --inplace
+    python -m adeft.download
     nosetests adeft -v --with-coverage --cover-inclusive --cover-package=adeft
 extras =
     test


### PR DESCRIPTION
This PR wraps the commands necessary to run the tests with `tox`. This makes it much easier for end users to run the tests on their systems and reduces the number of places that it needs to be documented (including in the GHA config). Note: this doesn't solve the issue of failure on windows