### PR TITLE
Update setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
-# Inside of setup.cfg
 [metadata]
-description-file = README.md
+description_file = README.md
+long_description_content_type = text/markdown


### PR DESCRIPTION
The dash syntax is deprecated, and this adds the MIME type for correct display on PyPI (though it looks like it's fine on PyPI already...)