### PR TITLE
Pytest

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,4 +23,4 @@ jobs:
           python -m adeft.download
       - name: Test with nose
         run:
-          nosetests adeft -v --with-coverage --cover-inclusive --cover-package=adeft
+          pytest --cov=adeft

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,6 @@ jobs:
           pip install .[test]
           python setup.py build_ext --inplace
           python -m adeft.download
-      - name: Test with nose
+      - name: Test with pytest
         run:
           pytest --cov=adeft

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,3 @@
 include adeft/nlp/stopwords.json
+graft adeft/gui/ground/static
+graft adeft/gui/ground/templates

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Jupyter notebooks illustrating Adeft workflows are available under `notebooks`:
 
 ## Testing
 
-Adeft uses `nosetests` for unit testing, and is integrated with the Travis
+Adeft uses `pytest` for unit testing, and uses Github Actions as a
 continuous integration environment. To run tests locally, make sure
 to install the test-specific requirements listed in setup.py as
 
@@ -91,7 +91,7 @@ pip install adeft[test]
 ```
 
 and download all pre-trained models as shown above.
-Then run `nosetests` in the top-level `adeft` folder.
+Then run `pytest` in the top-level `adeft` folder.
 
 ## Funding
 

--- a/adeft/disambiguate.py
+++ b/adeft/disambiguate.py
@@ -173,8 +173,8 @@ class AdeftDisambiguator(object):
                         FP += row
             Pr = TP/(TP + FP)
             Rc = TP/(TP + FN)
-            Pr[Pr == np.float('inf')] = 0.
-            Rc[Rc == np.float('inf')] = 0.
+            Pr[Pr == float('inf')] = 0.
+            Rc[Rc == float('inf')] = 0.
             F1 = 2/(1/Pr + 1/Rc)
             stats['f1']['mean'] = np.round(np.mean(F1), 6)
             stats['f1']['std'] = np.round(np.std(F1), 6)

--- a/adeft/gui/ground/__init__.py
+++ b/adeft/gui/ground/__init__.py
@@ -36,7 +36,9 @@ def create_app(longforms, scores,
                 identifiers_dict[namespace]['id_name'][identifier] = name
     identifiers_dict = dict(identifiers_dict)
 
-    app = Flask(__name__)
+    here = os.path.dirname(os.path.realpath(__file__))
+    app = Flask(__name__,
+                template_folder=os.path.join(here, 'templates'))
     # longforms, scores, and outpath will not change. These can be stored
     # in config variables
     app.config.from_mapping(SECRET_KEY='dev',

--- a/adeft/gui/ground/__init__.py
+++ b/adeft/gui/ground/__init__.py
@@ -36,9 +36,7 @@ def create_app(longforms, scores,
                 identifiers_dict[namespace]['id_name'][identifier] = name
     identifiers_dict = dict(identifiers_dict)
 
-    here = os.path.dirname(os.path.realpath(__file__))
-    app = Flask(__name__,
-                template_folder=os.path.join(here, 'templates'))
+    app = Flask(__name__)
     # longforms, scores, and outpath will not change. These can be stored
     # in config variables
     app.config.from_mapping(SECRET_KEY='dev',

--- a/adeft/gui/ground/ground.py
+++ b/adeft/gui/ground/ground.py
@@ -6,8 +6,7 @@ from numpy import argsort
 from flask import Blueprint, request, render_template, session, current_app
 
 here = os.path.dirname(os.path.realpath(__file__))
-bp = Blueprint('ground', __name__,
-               template_folder=os.path.join(here, 'templates'))
+bp = Blueprint('ground', __name__)
 
 
 @bp.route('/ground_add', methods=['POST'])

--- a/adeft/gui/ground/ground.py
+++ b/adeft/gui/ground/ground.py
@@ -5,7 +5,9 @@ from numpy import argsort
 
 from flask import Blueprint, request, render_template, session, current_app
 
-bp = Blueprint('ground', __name__)
+here = os.path.dirname(os.path.realpath(__file__))
+bp = Blueprint('ground', __name__,
+               template_folder=os.path.join(here, 'templates'))
 
 
 @bp.route('/ground_add', methods=['POST'])

--- a/adeft/tests/test_classify.py
+++ b/adeft/tests/test_classify.py
@@ -2,7 +2,6 @@ import os
 import uuid
 import json
 import numpy as np
-from nose.plugins.attrib import attr
 from sklearn.metrics import f1_score
 
 from adeft.locations import TEST_RESOURCES_PATH
@@ -22,7 +21,6 @@ with open(os.path.join(TEST_RESOURCES_PATH,
 
 # The classifier works slightly differently for multiclass than it does for
 # binary labels. Both cases must be tested separately.
-@attr('slow')
 def test_train():
     params = {'C': 1.0,
               'ngram_range': (1, 2),

--- a/adeft/tests/test_classify.py
+++ b/adeft/tests/test_classify.py
@@ -47,7 +47,6 @@ def test_train():
     assert np.array_equal(coef1, coef2)
 
 
-@attr('slow')
 def test_cv_multiclass():
     params = {'C': [1.0],
               'max_features': [10]}
@@ -65,7 +64,6 @@ def test_cv_multiclass():
     assert np.array_equal(coef1, coef2)
 
 
-@attr('slow')
 def test_cv_binary():
     params = {'C': [1.0],
               'max_features': [10]}

--- a/adeft/tests/test_disambiguate.py
+++ b/adeft/tests/test_disambiguate.py
@@ -2,8 +2,8 @@ import os
 import uuid
 import json
 import shutil
+import pytest
 import logging
-from nose.tools import raises
 
 from numpy import array_equal
 
@@ -115,7 +115,7 @@ def test_update_pos_labels():
                                        'MESH:D007333'])
 
 
-@raises(ValueError)
 def test_modify_groundings_error():
     ad = load_disambiguator('IR', path=TEST_MODEL_PATH)
-    ad.modify_groundings(new_groundings={'MESH:D011839': 'HGNC:6091'})
+    with pytest.raises(ValueError):
+        ad.modify_groundings(new_groundings={'MESH:D011839': 'HGNC:6091'})

--- a/adeft/tests/test_nlp.py
+++ b/adeft/tests/test_nlp.py
@@ -1,5 +1,4 @@
-from nose.tools import raises
-
+import pytest
 from adeft.nlp import WatchfulStemmer, word_tokenize, word_detokenize
 
 
@@ -31,7 +30,6 @@ def test_tokenize_untokenize():
         assert word_detokenize(result) == text
 
 
-@raises(ValueError)
 def test_watchful_stemmer():
     """Test the watchful stemmer"""
     stemmer = WatchfulStemmer()
@@ -51,4 +49,5 @@ def test_watchful_stemmer():
     assert stemmer.counts['verbif']['verbifications'] == 3
 
     # raises value error if stem has not been observed
-    stemmer.most_frequent('ver')
+    with pytest.raises(ValueError):
+        stemmer.most_frequent('ver')

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(name='adeft',
       packages=find_packages(),
       install_requires=['nltk', 'scikit-learn>=0.20.0', 'wget',
                         'requests', 'flask', 'pystow'],
-      extras_require={'test': ['pytest']},
+      extras_require={'test': ['pytest', 'pytest-cov']},
       keywords=['nlp', 'biology', 'disambiguation'],
       ext_modules=extensions,
       include_package_data=True)

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(name='adeft',
       packages=find_packages(),
       install_requires=['nltk', 'scikit-learn>=0.20.0', 'wget',
                         'requests', 'flask', 'pystow'],
-      extras_require={'test': ['nose', 'coverage', 'python-coveralls']},
+      extras_require={'test': ['pytest']},
       keywords=['nlp', 'biology', 'disambiguation'],
       ext_modules=extensions,
       include_package_data=True)


### PR DESCRIPTION
This PR updates the tests to use pytest instead of nose, which is now deprecated. The jinja2, css and and javascript files for the flask based grounding GUI have been added to MANIFEST.in, allowing the grounding GUI to work when the app is pip installed.