### PR TITLE
Replace wget with boto3

### DIFF
--- a/adeft/download/download.py
+++ b/adeft/download/download.py
@@ -94,7 +94,7 @@ def download_resources():
                     os.path.join(loc.RESOURCES_PATH, resource), 'wb'
             ) as f_out:
                 shutil.copyfileobj(f_in, f_out)
-                os.remove(resource_path)
+        os.remove(resource_path)
 
 
 def setup_test_resource_folder():

--- a/adeft/download/download.py
+++ b/adeft/download/download.py
@@ -61,8 +61,8 @@ def download_models(models=None):
             resource_path = os.path.join(
                 loc.ADEFT_MODELS_PATH, model, resource
             )
-            # if resource already exists, remove it since wget will not
-            # overwrite existing files, choosing a new name instead
+            # if resource already exists, remove it. Ensures that
+            # models path stays in a consistent state.
             _remove_if_exists(resource_path)
             download_adeft_object(
                 'Models', model, resource, outpath=resource_path

--- a/adeft/download/download.py
+++ b/adeft/download/download.py
@@ -180,7 +180,7 @@ def get_s3_models():
 
 
 def download_adeft_object(*args, outpath):
-    print(f"Downloading {'/'.join(args)}")
+    logger.info(f"Downloading {'/'.join(args)}")
     return _anonymous_s3_download(loc.S3_BUCKET, _get_s3_key(*args), outpath)
 
 

--- a/adeft/locations.py
+++ b/adeft/locations.py
@@ -19,4 +19,6 @@ ADEFT_MODELS_PATH = os.path.join(ADEFT_PATH, 'models')
 RESOURCES_PATH = os.path.join(ADEFT_PATH, 'resources')
 GROUNDINGS_FILE_PATH = os.path.join(RESOURCES_PATH, 'groundings.csv')
 TEST_RESOURCES_PATH = os.path.join(ADEFT_PATH, 'test_resources')
-S3_BUCKET_URL = f'https://adeft.s3.amazonaws.com/{__version__}'
+S3_BUCKET = "adeft"
+BUCKET_REGION = "us-east-1"
+S3_KEY_PREFIX = __version__

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -2,7 +2,6 @@ sphinx
 sphinx_rtd_theme
 scikit-learn>=0.20.0
 nltk
-wget
-requests
+boto3
 flask
 appdirs

--- a/setup.py
+++ b/setup.py
@@ -46,8 +46,9 @@ setup(name='adeft',
           'Programming Language :: Python :: 3.9'
       ],
       packages=find_packages(),
-      install_requires=['nltk', 'scikit-learn>=0.20.0', 'wget',
-                        'requests', 'flask', 'appdirs'],
+      install_requires=[
+          'nltk', 'scikit-learn>=0.20.0', 'boto3', 'flask', 'appdirs'
+      ],
       extras_require={'test': ['pytest', 'pytest-cov']},
       keywords=['nlp', 'biology', 'disambiguation'],
       ext_modules=extensions,


### PR DESCRIPTION
This PR updates how models and other resources are downloaded from s3. Previously an unmaintained Python package [wget](https://pypi.org/project/wget/) was used to download objects from s3 based upon their URL. This was done for convenience, since at the time I wasn't sure of how to download with boto3 without requiring credentials. The `wget` package also prints a nice progress-bar for each download.

It has come to my attention that the URL based downloads have been flaky, with individual downloads failing unexpectedly at times, causing test failures on github actions. Each model is downloaded with a separate request, so as the number of models grew, the likelihood of at least one failure increased. 

`boto3` should be more reliable than wget, and this fix should hopefully stop these annoying test failures.