### PR TITLE
Bump to version 0.13.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Open Source Software,* 5(45), 1708, https://doi.org/10.21105/joss.01708
 
 ## Installation
 
-Adeft works with Python versions 3.5 and above. It is available on PyPi and can be installed with the command
+Adeft works with Python versions 3.8 and above. It is available on PyPi and can be installed with the command
 
     $ pip install adeft
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ maintainers = [
             {name = "adeft developers", email = "albert.steppi@gmail.com"}
 ]
 
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = [
              "nltk",
              "scikit-learn>=1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "adeft"
-version = "0.13.0-dev"
+version = "0.13.0"
 keywords=['nlp', 'biology', 'disambiguation']
 license = {file = "LICENSE"}
 description = "Acromine based Disambiguation of Entities From Text"

--- a/src/adeft/__init__.py
+++ b/src/adeft/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.12.3'
+__version__ = '0.13.0'
 
 from adeft.download import get_available_models
 


### PR DESCRIPTION
This PR bumps to version 0.13.0 in preparation for a new release. I also fixed some inconsistencies in Python requirements vs documented requirements.