### PR TITLE
Make some updates and fixes for new release with auto-adeft models

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,9 @@ jobs:
       - name: Install dependencies
         run: |
           pip install .[test]
+          # indra is used in one test for validating identifiers produced by
+          # the adeft models, but we don't need to pull in the dependencies.
+          pip install indra --no-deps
           python -m adeft.download
       - name: Test with pytest
         run:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest ]
-        python-version: ["3.8", "3.9", "3.10", "3.11" , "3.12", "3.13"]
+        python-version: ["3.10", "3.11" , "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "adeft"
-version = "0.13.0"
+version = "0.14.0-dev"
 keywords=['nlp', 'biology', 'disambiguation']
 license = {file = "LICENSE"}
 description = "Acromine based Disambiguation of Entities From Text"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ maintainers = [
             {name = "adeft developers", email = "albert.steppi@gmail.com"}
 ]
 
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
              "nltk",
              "scikit-learn>=1.0",
@@ -24,13 +24,11 @@ readme = {file = "README.md", content-type = "text/markdown"}
 classifiers = [
           'Development Status :: 4 - Beta',
           'License :: OSI Approved :: BSD License',
-          'Programming Language :: Python :: 3.8',
-          'Programming Language :: Python :: 3.8',
-          'Programming Language :: Python :: 3.9',
           'Programming Language :: Python :: 3.10',
           'Programming Language :: Python :: 3.11',
           'Programming Language :: Python :: 3.12',
-	  'Programming Language :: Python :: 3.13',	
+	  'Programming Language :: Python :: 3.13',
+	  'Programming Language :: Python :: 3.14'
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,5 @@ classifiers = [
 [project.optional-dependencies]
 test = [
      "pytest",
-     "pytest-cov",
-     "indra"
+     "pytest-cov"
 ]

--- a/src/adeft/__init__.py
+++ b/src/adeft/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.13.0'
+__version__ = '0.14.0-dev'
 
 from adeft.download import get_available_models
 

--- a/src/adeft/disambiguate.py
+++ b/src/adeft/disambiguate.py
@@ -4,6 +4,7 @@ import os
 import json
 import logging
 import numpy as np
+from collections import defaultdict
 from hashlib import md5
 
 
@@ -87,11 +88,19 @@ class AdeftDisambiguator(object):
         # First disambiguate based on searching for defining patterns
         groundings = []
         for text in texts:
-            grounding = set()
+            groundings_for_text = defaultdict(list)
+            seen_longforms = set()
             for recognizer in self.recognizers:
-                grounding.update({x['grounding']
-                                  for x in recognizer.recognize(text)})
-            groundings.append(grounding)
+                results = recognizer.recognize(text)
+                for info in results:
+                    if not info:
+                        continue
+                    grounding = info["grounding"]
+                    longform = info["longform_text"]
+                    if longform not in seen_longforms:
+                        groundings_for_text[grounding].append(longform)
+                        seen_longforms.add(longform)
+            groundings.append(dict(groundings_for_text))
         # For texts without a defining pattern or with inconsistent
         # defining patterns, use the longform classifier.
         undetermined = [text for text, grounding in zip(texts, groundings)
@@ -109,23 +118,33 @@ class AdeftDisambiguator(object):
                 # if an unambiguous defining pattern exists, use this
                 # as the disambiguation. set the probability of this
                 # grounding to one
-                disamb = grounding.pop()
-                pred = {label: 0. for label in self.labels}
-                pred[disamb] = 1.0
-                result[index] = (disamb, self.names.get(disamb), pred)
+                disamb, longforms = list(grounding.items())[0]
+                pred = {str(label): 0. for label in self.labels}
+                pred[str(disamb)] = 1.0
+                result[index] = {
+                    "decision": disamb,
+                    "name": self.names.get(disamb),
+                    "predicted_probabilities": pred,
+                    "defining_patterns": grounding,
+                }
             elif grounding:
                 # if inconsistent defining patterns exist, disambiguate
                 # to the one with highest predicted probability. Set the
                 # probability of the multiple groundings to sum to one
-                unnormed = {label: preds[pred_index][label] if
-                            label in grounding else 0.
+                unnormed = {str(label): preds[pred_index].get(label, 0.0)
+                            if label in grounding else 0.
                             for label in self.labels}
                 norm_factor = sum(unnormed.values())
                 pred = {label: prob/norm_factor
                         for label, prob in unnormed.items()}
                 disamb = max(pred.keys(),
                              key=lambda key: pred[key])
-                result[index] = (disamb, self.names.get(disamb), pred)
+                result[index] = {
+                    "decision": str(disamb),
+                    "name": self.names.get(disamb),
+                    "predicted_probabilities": pred,
+                    "defining_patterns": grounding,
+                }
                 pred_index += 1
             else:
                 # otherwise use the longform classifier directly
@@ -133,7 +152,12 @@ class AdeftDisambiguator(object):
                         for label, prob in preds[pred_index].items()}
                 disamb = max(pred.keys(),
                              key=lambda key: pred[key])
-                result[index] = (disamb, self.names.get(disamb), pred)
+                result[index] = {
+                    "decision": disamb,
+                    "name": self.names.get(disamb),
+                    "predicted_probabilities": pred,
+                    "defining_patterns": None,
+                }
                 pred_index += 1
         return result
 

--- a/src/adeft/disambiguate.py
+++ b/src/adeft/disambiguate.py
@@ -124,7 +124,7 @@ class AdeftDisambiguator(object):
                 result[index] = {
                     "decision": disamb,
                     "name": self.names.get(disamb),
-                    "predicted_probabilities": pred,
+                    "predicted_probs": pred,
                     "defining_patterns": grounding,
                 }
             elif grounding:
@@ -142,7 +142,7 @@ class AdeftDisambiguator(object):
                 result[index] = {
                     "decision": str(disamb),
                     "name": self.names.get(disamb),
-                    "predicted_probabilities": pred,
+                    "predicted_probs": pred,
                     "defining_patterns": grounding,
                 }
                 pred_index += 1
@@ -155,7 +155,7 @@ class AdeftDisambiguator(object):
                 result[index] = {
                     "decision": disamb,
                     "name": self.names.get(disamb),
-                    "predicted_probabilities": pred,
+                    "predicted_probs": pred,
                     "defining_patterns": None,
                 }
                 pred_index += 1

--- a/src/adeft/disambiguate.py
+++ b/src/adeft/disambiguate.py
@@ -6,6 +6,7 @@ import logging
 import numpy as np
 from collections import defaultdict
 from hashlib import md5
+from typing import NamedTuple
 
 
 from adeft.locations import ADEFT_MODELS_PATH
@@ -14,6 +15,13 @@ from adeft.modeling.classify import load_model
 from adeft.download import get_available_models
 
 logger = logging.getLogger(__file__)
+
+
+class DisambResult(NamedTuple):
+    decision: str
+    name: str
+    predicted_probs: dict[str, float]
+    defining_patterns: dict[str, list[str]]
 
 
 class AdeftDisambiguator(object):
@@ -78,9 +86,14 @@ class AdeftDisambiguator(object):
         -------
         result : tuple or list of tuple
             Disambiguations for text. For each text the corresponding
-            disambiguation is a tuple of three elements. A grounding,
-            a canonical name associated with the grounding, and a dictionary
-            containing predicted probabilities for each possible grounding
+            disambiguation is a named tuple of four elements. A grounding,
+            a canonical name associated with the grounding, a dictionary
+            containing predicted probabilities for each available grounding,
+            and a dictionary mapping groundings to longform expansions for
+            that grounding found based on defining patterns. Typically the
+            defining patterns dict contains only one entry, because it is
+            rare to have conflicting longform expansions.
+
         """
         # Handle case where a single string is passed
         if isinstance(texts, str):
@@ -121,12 +134,12 @@ class AdeftDisambiguator(object):
                 disamb, longforms = list(grounding.items())[0]
                 pred = {str(label): 0. for label in self.labels}
                 pred[str(disamb)] = 1.0
-                result[index] = {
-                    "decision": disamb,
-                    "name": self.names.get(disamb),
-                    "predicted_probs": pred,
-                    "defining_patterns": grounding,
-                }
+                result[index] = DisambResult(
+                    str(disamb),
+                    self.names.get(disamb),
+                    pred,
+                    grounding,
+                )
             elif grounding:
                 # if inconsistent defining patterns exist, disambiguate
                 # to the one with highest predicted probability. Set the
@@ -135,16 +148,16 @@ class AdeftDisambiguator(object):
                             if label in grounding else 0.
                             for label in self.labels}
                 norm_factor = sum(unnormed.values())
-                pred = {label: prob/norm_factor
+                pred = {label: float(prob/norm_factor)
                         for label, prob in unnormed.items()}
                 disamb = max(pred.keys(),
                              key=lambda key: pred[key])
-                result[index] = {
-                    "decision": str(disamb),
-                    "name": self.names.get(disamb),
-                    "predicted_probs": pred,
-                    "defining_patterns": grounding,
-                }
+                result[index] = DisambResult(
+                    str(disamb),
+                    self.names.get(disamb),
+                    pred,
+                    grounding,
+                )
                 pred_index += 1
             else:
                 # otherwise use the longform classifier directly
@@ -152,12 +165,12 @@ class AdeftDisambiguator(object):
                         for label, prob in preds[pred_index].items()}
                 disamb = max(pred.keys(),
                              key=lambda key: pred[key])
-                result[index] = {
-                    "decision": disamb,
-                    "name": self.names.get(disamb),
-                    "predicted_probs": pred,
-                    "defining_patterns": None,
-                }
+                result[index] = DisambResult(
+                    disamb,
+                    self.names.get(disamb),
+                    pred,
+                    {},
+                )
                 pred_index += 1
         return result
 

--- a/src/adeft/disambiguate.py
+++ b/src/adeft/disambiguate.py
@@ -404,23 +404,31 @@ class AdeftDisambiguator(object):
         name_pad = max((len(val) for val in self.names.values()))
         count_pad = max(len(str(count)) for count
                         in label_distribution.values())
-        metric_pad = metric_digits + 2
-        header = '%s\t%s\t%s\n' % ('Grounding'.ljust(name_pad),
-                                   'Count'.ljust(count_pad),
-                                   'F1'.ljust(metric_pad))
+        metric_pad = metric_digits + 4
+        header = '%s\t%s\t%s\t%s\t%s\n' % ('Grounding'.ljust(name_pad),
+                                           'Count'.rjust(count_pad),
+                                           'F1'.rjust(metric_pad),
+                                           'Precision'.rjust(metric_pad),
+                                           'Recall'.rjust(metric_pad))
         output += header
         for grounding, count in sorted(label_distribution.items(),
                                        key=lambda x: - x[1]):
-            name = (self.names[grounding]
-                    if grounding in self.names else 'Ungrounded')
+            name = self.names.get(grounding, "Ungrounded")
             pos = '*' if grounding in self.pos_labels else ''
-            try:
-                f1 = round(model_stats[grounding]['f1']['mean'], metric_digits)
-            except KeyError:
-                f1 = ''
-            output += '%s%s\t%s\t%s\n' % (name.rjust(name_pad), pos,
-                                          str(count).rjust(count_pad),
-                                          str(f1).rjust(metric_pad))
+            name += pos
+            f1 = model_stats[grounding].get('f1')
+            pr = model_stats[grounding].get('pr')
+            rc = model_stats[grounding].get('rc')
+            f1 = str(round(f1["mean"], metric_digits)) if f1 is not None else ''
+            pr = str(round(pr["mean"], metric_digits)) if pr is not None else ''
+            rc = str(round(rc["mean"], metric_digits)) if rc is not None else ''
+            count = str(count)
+
+            output += '%s\t%s\t%s\t%s\t%s\n' % (name.ljust(name_pad),
+                                                  count.rjust(count_pad),
+                                                  f1.rjust(metric_pad),
+                                                  pr.rjust(metric_pad),
+                                                  rc.rjust(metric_pad))
         output += '\n'
         output += 'Global Metrics:\n'
         output += '-----------------\n'

--- a/src/adeft/disambiguate.py
+++ b/src/adeft/disambiguate.py
@@ -148,7 +148,7 @@ class AdeftDisambiguator(object):
                 pred_index += 1
             else:
                 # otherwise use the longform classifier directly
-                pred = {label: prob
+                pred = {str(label): prob
                         for label, prob in preds[pred_index].items()}
                 disamb = max(pred.keys(),
                              key=lambda key: pred[key])

--- a/src/adeft/download/download.py
+++ b/src/adeft/download/download.py
@@ -175,7 +175,7 @@ def get_s3_models():
         )
     except botocore.exceptions.ClientError:
         logger.warning("Online Adeft models not available.")
-        return
+        return {}
     return json.loads(response["Body"].read())
 
 

--- a/src/adeft/modeling/classify.py
+++ b/src/adeft/modeling/classify.py
@@ -71,14 +71,14 @@ class BaselineLogisticRegressionModel(BaseModel):
         'max_features': 'tfidf',
         'stop_words': 'tfidf',
         'C': 'logit',
-        'penalty': 'logit',
+        'l1_ratio': 'logit',
         'class_weight': 'logit',
         'random_state': 'logit',
         }
-    def __init__(self, *, stop_words=None, ngram_range=(1, 2), C=100.0, penalty='l1',
+    def __init__(self, *, stop_words=None, ngram_range=(1, 2), C=100.0, l1_ratio=1.0,
                  max_features=1000, class_weight=None, random_state=None):
         self.C = C
-        self.penalty = penalty
+        self.l1_ratio = l1_ratio
         self.class_weight = class_weight
         self.ngram_range = ngram_range
         self.max_features = max_features
@@ -91,7 +91,7 @@ class BaselineLogisticRegressionModel(BaseModel):
                                   ('logit',
                                    LogisticRegression(C=C,
                                                       solver='saga',
-                                                      penalty=penalty,
+                                                      l1_ratio = 1.0,
                                                       random_state=random_state,
                                                       max_iter=1000))])
         self._feature_stds = None
@@ -193,7 +193,7 @@ class BaselineLogisticRegressionModel(BaseModel):
                 "intercept_": intercept_,
                 "coef_": coef_,
                 "C": self.C,
-                "penalty": self.penalty,
+                "l1_ratio": self.l1_ratio,
                 "class_weight": self.class_weight,
 
             },
@@ -218,7 +218,7 @@ class BaselineLogisticRegressionModel(BaseModel):
         tfidf.idf_ = np.asarray(model_info["tfidf"]["idf_"])
         logit = LogisticRegression(
             C=model_info["logit"].get("C", 1.0),
-            penalty=model_info["logit"].get("penalty", "l2"),
+            l1_ratio=model_info["logit"].get("l1_ratio", 1.0),
             class_weight=model_info["logit"].get("class_weight"),
         )
 
@@ -230,7 +230,7 @@ class BaselineLogisticRegressionModel(BaseModel):
             stop_words=tfidf.stop_words,
             ngram_range=tfidf.ngram_range,
             C=logit.C,
-            penalty=logit.penalty,
+            l1_ratio=logit.l1_ratio,
             max_features=tfidf.max_features,
             class_weight=logit.class_weight,
         )

--- a/src/adeft/util.py
+++ b/src/adeft/util.py
@@ -2,6 +2,7 @@
 
 """
 import re
+from typing import List
 from unicodedata import category
 
 from adeft.nlp import word_tokenize, word_detokenize
@@ -182,3 +183,8 @@ def str2filename(name: str) -> str:
         filesystems.
     """
     return ''.join(f'_{c.upper()}' if c.islower() else c for c in name)
+
+
+def get_model_name(shortforms: List[str]) -> str:
+    """Get the canonical name associated to model for given shortforms."""
+    return "&".join(sorted(str2filename(shortform) for shortform in shortforms))

--- a/src/adeft/util.py
+++ b/src/adeft/util.py
@@ -185,7 +185,7 @@ def str2filename(name: str) -> str:
     return ''.join(f'_{c.upper()}' if c.islower() else c for c in name)
 
 
-def get_model_name(shortforms: List[str]) -> str:
+def get_canonical_model_name(shortforms: List[str]) -> str:
     """Get the canonical name associated to model for given shortforms.
 
     Parameters

--- a/src/adeft/util.py
+++ b/src/adeft/util.py
@@ -186,5 +186,17 @@ def str2filename(name: str) -> str:
 
 
 def get_model_name(shortforms: List[str]) -> str:
-    """Get the canonical name associated to model for given shortforms."""
-    return "&".join(sorted(str2filename(shortform) for shortform in shortforms))
+    """Get the canonical name associated to model for given shortforms.
+
+    Parameters
+    ----------
+    shortforms : list[str]
+
+    Returns
+    -------
+    str
+        A canonical model name which can be used safely in file or directory
+        names on case insensitive filesystems.
+
+    """
+    return str2filename("&".join(sorted(shortforms)))

--- a/tests/test_disambiguate.py
+++ b/tests/test_disambiguate.py
@@ -80,21 +80,22 @@ def test_disambiguate():
     ad = AdeftDisambiguator(test_model, grounding_dict, names)
     # case where there is a unique defining pattern
     disamb1 = ad.disambiguate(example1)
-    assert disamb1[0] == 'HGNC:6091'
-    assert disamb1[1] == 'INSR'
-    assert disamb1[2]['HGNC:6091'] == 1.0
-    assert disamb1[2]['MESH:D011839'] == 0.0
+    assert disamb1["decision"] == 'HGNC:6091'
+    assert disamb1["name"] == 'INSR'
+    assert disamb1["predicted_probs"]['HGNC:6091'] == 1.0
+    assert disamb1["predicted_probs"]['MESH:D011839'] == 0.0
+
 
     # case where there are conflicting defining patterns
     disamb2 = ad.disambiguate(example2)
-    preds = disamb2[2]
+    preds = disamb2["predicted_probs"]
     nonzero = {key for key, value in preds.items() if value > 0.0}
     assert nonzero == {'HGNC:6091', 'MESH:D007333'}
 
     # case without a defining pattern
     disamb3 = ad.disambiguate(example3)
-    assert disamb3[0] == 'HGNC:6091'
-    assert disamb3[1] == 'INSR'
+    assert disamb3["decision"] == 'HGNC:6091'
+    assert disamb3["name"] == 'INSR'
 
 
 def test_modify_groundings():

--- a/tests/test_disambiguate.py
+++ b/tests/test_disambiguate.py
@@ -80,22 +80,22 @@ def test_disambiguate():
     ad = AdeftDisambiguator(test_model, grounding_dict, names)
     # case where there is a unique defining pattern
     disamb1 = ad.disambiguate(example1)
-    assert disamb1["decision"] == 'HGNC:6091'
-    assert disamb1["name"] == 'INSR'
-    assert disamb1["predicted_probs"]['HGNC:6091'] == 1.0
-    assert disamb1["predicted_probs"]['MESH:D011839'] == 0.0
+    assert disamb1.decision == 'HGNC:6091'
+    assert disamb1.name == 'INSR'
+    assert disamb1.predicted_probs['HGNC:6091'] == 1.0
+    assert disamb1.predicted_probs['MESH:D011839'] == 0.0
 
 
     # case where there are conflicting defining patterns
     disamb2 = ad.disambiguate(example2)
-    preds = disamb2["predicted_probs"]
+    preds = disamb2.predicted_probs
     nonzero = {key for key, value in preds.items() if value > 0.0}
     assert nonzero == {'HGNC:6091', 'MESH:D007333'}
 
     # case without a defining pattern
     disamb3 = ad.disambiguate(example3)
-    assert disamb3["decision"] == 'HGNC:6091'
-    assert disamb3["name"] == 'INSR'
+    assert disamb3.decision == 'HGNC:6091'
+    assert disamb3.name == 'INSR'
 
 
 def test_modify_groundings():


### PR DESCRIPTION
This PR makes some minor updates and fixes that came out of my work on automating the adeft model construction process. The changes are:

* Adding a function for getting a canonical name for an adeft model that disambiguates a list of shortforms.  Canonical names are needed because Adeft uses these model names in filenames, and the canonical name must be case insensitive and avoid special characters that cannot appear in filenames on one or more supported platforms.

* Change the output of `AdeftDisambiguator.disambiguate` from lists of tuples to lists of named tuples and add an entry for `defining_patterns` which contains a `dict` mappings grounding curies to lists of longform expansions found with defining patterns, if any. Usually these dicts will not contain no more than one grounding, but there are rare cases where there are conflicting expansions.
* Fix a bug that could occur in `AdeftDisambiguator.disambiguate` when there are labels that can be recognized by longform expansion but not by the `AdeftClassifier` due to insufficient training data being available. This was fixed by adding a step to setthe probability in the `preds` dict for such groundings to `0.0`, instead of omitting them from the `preds` dict.
* Fix a bug that occurred when the name associated to a grounding is `None` There were some steps in the automated model construction where this could happen. Longer term I should look into making sure each grounding has a name, but for now, it's better not to raise if it happens. 
* Updated `disamb.info`'s table to show more information.
* Change use of `LogisticRegression` from `sklearn` to not use the deprecated `penalty` kwarg, but instead use `l1_ratio`. I was getting a lot of warnings due to this when I updated to the latest `sklearn`.
